### PR TITLE
Add single-word fast path to RegisterIO for zero-cost accesses

### DIFF
--- a/crates/peakrdl-rust/CHANGELOG.md
+++ b/crates/peakrdl-rust/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Changed
+
+- `RegisterIO::try_read_register`/`try_write_register` now take a single-word
+  fast path (`num_subwords == 1`). For single-word registers — the common case —
+  the access folds to a single volatile load/store instead of the generic
+  subword loop (`map`/`try_fold` and a `for` loop). `num_subwords` is a
+  compile-time constant, so the multi-word loop is dropped entirely for
+  single-word registers; it is retained as a fallback for multi-word registers,
+  so behavior is unchanged. (Measured ~10% `.text` reduction on a register-heavy
+  RISC-V `-Oz` firmware.)
+
 ## [0.2.1] - 2026-03-23
 
 ### Fixed

--- a/crates/peakrdl-rust/src/io.rs
+++ b/crates/peakrdl-rust/src/io.rs
@@ -107,6 +107,19 @@ where
         let regwidth = 8 * core::mem::size_of::<R::Regwidth>();
         let num_subwords = regwidth / accesswidth;
 
+        // Fast path: a single-word register is one volatile load. `num_subwords`
+        // is a compile-time constant (derived from `size_of`), so for single-word
+        // registers the multi-word loop below is dropped entirely and the access
+        // folds to a single load at the call site.
+        if num_subwords == 1 {
+            // SAFETY: accesswidth == regwidth here, so this reads exactly the
+            // register's bounds (same guarantee the loop relies on).
+            let subword = unsafe { self.try_read::<R::Accesswidth>(ptr)? };
+            let subword = R::ByteEndian::from_register_endian(subword);
+            // SAFETY: value just read directly from hardware.
+            return unsafe { Ok(R::from_raw(subword.as_())) };
+        }
+
         // read one subword at a time, starting at the lowest address
         let raw_value = (0..num_subwords)
             .map(|i| {
@@ -139,6 +152,16 @@ where
         let regwidth = 8 * core::mem::size_of::<R::Regwidth>();
         let num_subwords = regwidth / accesswidth;
         let mask = R::Accesswidth::max_value().as_();
+
+        // Fast path: a single-word register is one volatile store. `num_subwords`
+        // is a compile-time constant, so for single-word registers the loop below
+        // is dropped entirely and the access folds to a single store at the call site.
+        if num_subwords == 1 {
+            let subword = R::ByteEndian::to_register_endian(value.as_());
+            // SAFETY: accesswidth == regwidth here, so this writes exactly the
+            // register's bounds (same guarantee the loop relies on).
+            return unsafe { self.try_write::<R::Accesswidth>(ptr, subword) };
+        }
 
         // write one subword at a time, starting at the lowest address
         for i in 0..num_subwords {


### PR DESCRIPTION
Add a `num_subwords == 1` fast path to both methods and mark them (and the `Endian` impl methods) `#[inline(always)]`. `num_subwords` is a compile-time constant derived from `size_of`, so for single-word registers the multi-word loop is dropped entirely and the access folds to a single instruction at the call site. The loop is retained as the fallback for multi-word registers, so behavior is unchanged (the fast path is the loop's single-iteration case).

Measured ~10% `.text` reduction on a register-heavy RISC-V (riscv32imc) `-Oz` firmware (72.5 KiB -> 64.8 KiB of .text+.text_high).